### PR TITLE
feat: VSCode extension should now also work with vscodium and cursor

### DIFF
--- a/scripts/reopen.sh
+++ b/scripts/reopen.sh
@@ -2,6 +2,8 @@
 
 set -eu -o pipefail
 
+editor=${1:-code}
+
 # Get the file descriptor from NODE_CHANNEL_FD
 fd="${NODE_CHANNEL_FD:-3}"
 
@@ -13,6 +15,6 @@ send() {
 send '{"action":"close"}'
 
 while IFS= read -u "$fd" -r line; do
-    flox activate -- bash -c "code -nw --verbose $PWD" 
+    flox activate -- bash -c "$editor -nw --verbose $PWD" 
     break
 done

--- a/scripts/reopen.sh
+++ b/scripts/reopen.sh
@@ -15,6 +15,6 @@ send() {
 send '{"action":"close"}'
 
 while IFS= read -u "$fd" -r line; do
-    flox activate -- bash -c "$editor -nw --verbose $PWD" 
+    flox activate -- bash -c "$editor --new-window --wait --verbose $PWD" 
     break
 done

--- a/scripts/reopen.sh
+++ b/scripts/reopen.sh
@@ -2,13 +2,8 @@
 
 set -eu -o pipefail
 
-#echo "START" >  /tmp/test.out
-#echo " => PATH: $PWD" >> /tmp/test.out
-
-## Get the file descriptor from NODE_CHANNEL_FD
+# Get the file descriptor from NODE_CHANNEL_FD
 fd="${NODE_CHANNEL_FD:-3}"
-
-#echo " => NODE_CHANNEL_FD: $NODE_CHANNEL_FD" >> /tmp/test.out
 
 # Function to send a response back to Node.js
 send() {
@@ -17,16 +12,7 @@ send() {
 
 send '{"action":"close"}'
 
-# Read JSON messages from the file descriptor
 while IFS= read -u "$fd" -r line; do
-
-    # Print the message received for debugging
-    #echo " => MESSAGE: $line" >> /tmp/test.out
-
-    #echo -n " => FLOX ACTIVATE" >> /tmp/test.out
-    flox activate -- bash -c "echo ' => CODE' >> /tmp/test.out && code -n --verbose $PWD" 
-    #&> /tmp/test.out
-
-    # Break after handling the first message
+    flox activate -- bash -c "code -nw --verbose $PWD" 
     break
 done

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,12 @@ import { View, System, Packages, Package, Services } from './config';
 
 
 
+const EDITORS: { [key: string]: string } = {
+  "vscodium": "codium",
+  "visual studio code": "code",
+  "cursor": "cursor",
+};
+
 interface CommandExecOptions {
   argv: Array<string>;
   cwd?: boolean;
@@ -391,10 +397,11 @@ export default class Env implements vscode.Disposable {
   }
 
   public async reopen(_: any, reject: any, resolve: any) {
+    const editor = EDITORS[vscode.env.appName.toLocaleLowerCase()] || 'code';
     const reopenScript = vscode.Uri.joinPath(this.context.extensionUri, 'scripts', 'reopen.sh');
     console.log('reopen.sh path: ', reopenScript.fsPath);
 
-    let reopen = spawn(reopenScript.fsPath, {
+    let reopen = spawn(reopenScript.fsPath, [editor], {
       cwd: this.workspaceUri?.fsPath,
       stdio: [0, 1, 2, 'ipc']
     });


### PR DESCRIPTION
Also keep VSCode running on activate command. This allows services to be started.

Fixes #19 