### PR TITLE
feat: Add Flox output channel for debugging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,27 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
 import Env from './env';
 import { VarsView, InstallView, ServicesView, PackageItem, ServiceItem } from './view';
 
 export async function activate(context: vscode.ExtensionContext) {
 
+  const output = vscode.window.createOutputChannel('Flox');
+  context.subscriptions.push(output);
+
+  // Log startup info for debugging
+  const timestamp = new Date().toISOString();
+  output.appendLine(`[${timestamp}] Flox extension starting...`);
+  output.appendLine(`[${timestamp}] System: ${os.platform()} ${os.arch()}`);
+  output.appendLine(`[${timestamp}] VSCode: ${vscode.version}`);
+  if (vscode.workspace.workspaceFolders?.[0]) {
+    output.appendLine(`[${timestamp}] Workspace: ${vscode.workspace.workspaceFolders[0].uri.fsPath}`);
+  }
+
   const installView = new InstallView();
   const varsView = new VarsView();
   const servicesView = new ServicesView();
 
-  const env = new Env(context);
+  const env = new Env(context, undefined, output);
 
   env.registerView('floxInstallView', installView);
   env.registerView('floxVarsView', varsView);

--- a/src/test/mocks/vscode.ts
+++ b/src/test/mocks/vscode.ts
@@ -285,3 +285,74 @@ export function createMockCallTracker(): MockCallTracker {
     commandRegistrations: [],
   };
 }
+
+/**
+ * MockOutputChannel - Implements vscode.OutputChannel
+ *
+ * Used for testing output channel functionality. Captures all appended
+ * lines so tests can verify logging behavior.
+ *
+ * Key methods:
+ * - appendLine(value): Add a line to the output
+ * - getLines(): Get all logged lines (test helper)
+ * - clear(): Clear all logged lines
+ */
+export class MockOutputChannel implements vscode.OutputChannel {
+  readonly name: string;
+  private lines: string[] = [];
+
+  constructor(name: string = 'Flox') {
+    this.name = name;
+  }
+
+  append(value: string): void {
+    // For simplicity, we treat append as adding to the current line
+    if (this.lines.length === 0) {
+      this.lines.push(value);
+    } else {
+      this.lines[this.lines.length - 1] += value;
+    }
+  }
+
+  appendLine(value: string): void {
+    this.lines.push(value);
+  }
+
+  replace(_value: string): void {
+    // Not commonly used in our extension
+  }
+
+  clear(): void {
+    this.lines = [];
+  }
+
+  show(_preserveFocus?: boolean): void;
+  show(_column?: vscode.ViewColumn, _preserveFocus?: boolean): void;
+  show(_columnOrPreserveFocus?: vscode.ViewColumn | boolean, _preserveFocus?: boolean): void {
+    // No-op for mock
+  }
+
+  hide(): void {
+    // No-op for mock
+  }
+
+  dispose(): void {
+    this.lines = [];
+  }
+
+  // Test helper methods
+  getLines(): string[] {
+    return [...this.lines];
+  }
+
+  getLastLine(): string | undefined {
+    return this.lines.length > 0 ? this.lines[this.lines.length - 1] : undefined;
+  }
+
+  hasLine(pattern: string | RegExp): boolean {
+    if (typeof pattern === 'string') {
+      return this.lines.some(line => line.includes(pattern));
+    }
+    return this.lines.some(line => pattern.test(line));
+  }
+}


### PR DESCRIPTION
## Summary
- Add VSCode OutputChannel named "Flox" for logging debug information
- Users can view logs in Output panel (View > Output > Flox)
- Helps diagnose issues when things go wrong

## What's Logged
- Extension startup info (system, VSCode version, workspace path)
- Command execution with arguments and results
- File watcher events (manifest.toml/manifest.lock changes)
- Environment activation/deactivation lifecycle
- Environment variable application to terminals
- Errors with full context and stack traces

## Log Format
```
[2026-01-06T14:05:07.428Z] Flox extension starting...
[2026-01-06T14:05:07.428Z] System: darwin arm64
[2026-01-06T14:05:07.428Z] VSCode: 1.107.1
[2026-01-06T14:05:07.428Z] Workspace: /Users/rok/my-project
[2026-01-06T14:05:07.500Z] Reloading environment...
[2026-01-06T14:05:07.510Z] Environment loaded: 5 packages, 2 variables, 1 services
```

## Test plan
- [x] Open Output panel, select "Flox" dropdown
- [x] Verify startup info is logged on extension activation
- [x] Verify reload events are logged when manifest changes
- [x] Verify env var application is logged
- [x] All 80 tests pass (8 new logging tests)

Closes #44