### PR TITLE
chore: Add Claude Code project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(npm run compile:*)",
+      "Bash(npm test:*)",
+      "Bash(npm run test:unit:*)",
+      "Bash(npm run test:integration:*)",
+      "Bash(npm run lint:*)",
+      "WebFetch(domain:github.com)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with consolidated allowed commands for Claude Code
- Commands collected from all existing worktree settings
- Excludes git commands and `gh pr create` (kept local per worktree)

## Allowed Commands

- `gh issue view:*` - View GitHub issues
- `npm run compile:*` - Compile TypeScript
- `npm test:*` - Run all tests
- `npm run test:unit:*` - Run unit tests
- `npm run test:integration:*` - Run integration tests
- `npm run lint:*` - Run linter
- `WebFetch(domain:github.com)` - Fetch GitHub content

## Why

Project-level settings persist across Claude sessions for all contributors, reducing repetitive permission prompts for common development commands.