### PR TITLE
feat: Load from lock file with pending indicators

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,11 @@ export enum System {
   X86_64_DARWIN = "x86_64-darwin",
 }
 
+export enum ItemState {
+  ACTIVE = 'active',
+  PENDING = 'pending',
+}
+
 export type Package = {
   install_id: string,
   system: System,
@@ -15,6 +20,7 @@ export type Package = {
   license: string,
   description: string,
   attr_path: string,
+  state: ItemState,
 }
 
 export type Packages = Map<System, Map<string, Package>>
@@ -23,8 +29,15 @@ export type Service = {
   name: string,
   status: string,
   pid: number,
+  state?: ItemState,
 }
 export type Services = Map<string, Service>
+
+export type Variable = {
+  name: string,
+  value: string,
+  state: ItemState,
+}
 
 export interface View {
   registerProvider(viewName: string): vscode.Disposable;


### PR DESCRIPTION
## Summary

- Make `manifest.lock` the primary source of truth (active/committed state)
- Show `manifest.toml` items as "pending" with visual indicators (asterisk + warning color)
- Applies to all three views: InstallView, VarsView, ServicesView

## Changes

- **Bug fix**: Fixed copy-paste bug on line 158 in `env.ts` that was loading wrong file in fallback case
- **New types** (`config.ts`): Added `ItemState` enum (`ACTIVE`/`PENDING`) and `Variable` type
- **Merge logic** (`env.ts`): Loads both files, compares packages/vars/services, marks state
- **Visual indicators** (`view.ts`): Pending items show `nodejs *` with warning color + tooltip
- **Activation tracking**: `isActivationInProgress` flag, refreshes views when activation completes

## Visual Indicator

| State | Display |
|-------|---------|
| Active (in lock) | `nodejs` with normal icon |
| Pending (only in toml) | `nodejs *` with warning-colored icon |

## Test plan

- [x] 65 unit tests passing
- [x] 17 integration tests passing
- [x] New tests for pending state functionality
- [x] Manual testing: Edit manifest.toml, verify pending indicator appears
- [x] Manual testing: Run `flox activate`, verify items become active

Closes #148