### PR TITLE
chore: Add GitHub PR and git fetch permissions to Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,14 @@
   "permissions": {
     "allow": [
       "Bash(gh issue view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git fetch:*)",
       "Bash(npm run compile:*)",
-      "Bash(npm test:*)",
-      "Bash(npm run test:unit:*)",
-      "Bash(npm run test:integration:*)",
       "Bash(npm run lint:*)",
+      "Bash(npm run test:integration:*)",
+      "Bash(npm run test:unit:*)",
+      "Bash(npm test:*)",
       "WebFetch(domain:github.com)"
     ]
   }


### PR DESCRIPTION
## Summary
- Add `Bash(gh pr list:*)` permission for listing PRs
- Add `Bash(gh pr view:*)` permission for viewing PR details
- Add `Bash(git fetch:*)` permission for fetching remote changes
- Sort permissions alphabetically for consistency

## Test plan
- [x] Verify JSON syntax is valid
- [x] Test that Claude can use the new permissions