### PR TITLE
feat: Add command to show logs for running services

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,13 @@
         "title": "Restart a service"
       },
       {
+        "command": "flox.serviceLogs",
+        "category": "Flox",
+        "when": "flox.envActive",
+        "icon": "$(output)",
+        "title": "Show service logs"
+      },
+      {
         "command": "flox.edit",
         "category": "Flox",
         "title": "Edit manifest.toml"
@@ -212,6 +219,10 @@
           "command": "flox.activate",
           "when": "flox.isInstalled && flox.envExists",
           "group": "commandPalette"
+        },
+        {
+          "command": "flox.serviceLogs",
+          "when": "flox.envActive && flox.hasServices"
         }
       ],
       "view/title": [
@@ -269,6 +280,11 @@
         },
         {
           "command": "flox.serviceRestart",
+          "group": "inline",
+          "when": "flox.envActive && view == floxServicesView && viewItem == service-running"
+        },
+        {
+          "command": "flox.serviceLogs",
           "group": "inline",
           "when": "flox.envActive && view == floxServicesView && viewItem == service-running"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -488,6 +488,50 @@ export async function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  env.registerCommand('flox.serviceLogs', async (service: ServiceItem | undefined) => {
+    if (!env.workspaceUri) { return; }
+
+    // If service not provided (via Command Palette), show QuickPick of running services only
+    if (!service) {
+      const runningServices: vscode.QuickPickItem[] = [];
+      if (env?.servicesStatus) {
+        for (const [name, status] of env.servicesStatus) {
+          if (status?.status?.toLowerCase() === "running") {
+            runningServices.push({
+              label: name,
+              description: status?.status,
+            });
+          }
+        }
+      }
+
+      if (runningServices.length === 0) {
+        env.displayMsg("No running services to show logs for.");
+        return;
+      }
+
+      const selected = await vscode.window.showQuickPick(runningServices, {
+        placeHolder: 'Select a running service to show logs',
+      });
+      if (selected === undefined || selected?.label === undefined) {
+        env.displayMsg("No service selected.");
+        return;
+      }
+
+      service = new ServiceItem(selected.label, "", "running");
+    }
+
+    const terminalName = `flox: ${service.label} logs`;
+
+    // Reuse existing terminal if it exists
+    let terminal = vscode.window.terminals.find(t => t.name === terminalName);
+    if (!terminal) {
+      terminal = vscode.window.createTerminal({ name: terminalName });
+      terminal.sendText(`flox services logs --dir "${env.workspaceUri.fsPath}" --follow ${service.label}`, true);
+    }
+    terminal.show();
+  });
+
   env.registerCommand('flox.edit', async () => {
     if (!env.workspaceUri) { return; }
 

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -145,6 +145,12 @@ suite('Extension Integration Tests', () => {
       assert.ok(exists, 'flox.serviceRestart command should be registered');
     });
 
+    test('flox.serviceLogs command should be registered', async () => {
+      // Shows logs for a running service
+      const exists = await commandExists('flox.serviceLogs');
+      assert.ok(exists, 'flox.serviceLogs command should be registered');
+    });
+
     test('flox.edit command should be registered', async () => {
       // Opens manifest.toml in editor
       const exists = await commandExists('flox.edit');
@@ -171,6 +177,7 @@ suite('Extension Integration Tests', () => {
         'flox.serviceStart',
         'flox.serviceStop',
         'flox.serviceRestart',
+        'flox.serviceLogs',
         'flox.edit',
         'flox.search',
       ];


### PR DESCRIPTION
## Summary

- Add `flox.serviceLogs` command that opens a terminal with `flox services logs --follow`
- Show inline "Show Logs" button in services view for running services only
- Available via Command Palette (shows QuickPick filtered to running services)
- Reuses existing terminal if already open for that service

Closes #48

## Test plan

- [x] Unit tests pass (92 tests)
- [x] Integration tests pass (41 tests, includes new command registration test)
- [ ] Manual test: Start a service, click logs button, verify terminal opens with logs
- [ ] Manual test: Click logs again, verify same terminal is focused (not new one)
- [ ] Manual test: Use Command Palette → "Flox: Show service logs", verify QuickPick shows only running services