### PR TITLE
fix: Rename activation buttons to remove confusing '& Restart' terminology

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
       },
       {
         "view": "floxInfoView",
-        "contents": "[Activate & Restart](command:flox.activate)",
+        "contents": "[Activate Environment](command:flox.activate)",
         "when": "flox.isInstalled && flox.envExists && !flox.envActive"
       },
       {
         "view": "floxInfoView",
-        "contents": "[Deactivate & Restart](command:flox.deactivate)",
+        "contents": "[Deactivate Environment](command:flox.deactivate)",
         "when": "flox.isInstalled && flox.envExists && flox.envActive"
       },
       {


### PR DESCRIPTION
## Summary

Renames activation buttons to improve UX clarity by removing confusing '& Restart' terminology.

## Changes

- Changed **"Activate & Restart"** → **"Activate Environment"**
- Changed **"Deactivate & Restart"** → **"Deactivate Environment"**

## Why?

Users were confused by the "& Restart" terminology because:
1. It's not clear what "Restart" means in this context
2. The extension host/window restart is an implementation detail that shouldn't be exposed in the UI
3. The primary action is activating/deactivating the environment

## Testing

Manually verified the new button labels appear correctly in the Extension Development Host.

Fixes #183
Fixes #185