### PR TITLE
fix: Move 'Edit manifest.toml' button to packages section

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,13 +85,18 @@
         "when": "flox.isInstalled && !flox.envActive"
       },
       {
+        "view": "floxInstallView",
+        "contents": "Install packages to your environment.\n[Install a package](command:flox.install)\n[Edit manifest.toml](command:flox.edit)",
+        "when": "flox.isInstalled && flox.envExists && !flox.hasPkgs"
+      },
+      {
         "view": "floxVarsView",
-        "contents": "Add variable(s).\n[Edit manifest.toml](command:flox.edit)",
+        "contents": "Add variable(s) in manifest.toml.",
         "when": "flox.isInstalled && flox.envExists"
       },
       {
         "view": "floxServicesView",
-        "contents": "Add services(s).\n[Edit manifest.toml](command:flox.edit)",
+        "contents": "Add service(s) in manifest.toml.",
         "when": "flox.isInstalled && flox.envExists"
       },
       {


### PR DESCRIPTION
## Summary
Moves the "Edit manifest.toml" button from variables and services sections to the packages section where it belongs semantically.

## Changes
- ✅ Added InstallView welcome content with both "Install a package" and "Edit manifest.toml" buttons (shown when no packages installed)
- ✅ Removed "Edit manifest.toml" button from VarsView welcome content (kept helpful message)
- ✅ Removed "Edit manifest.toml" button from ServicesView welcome content (kept helpful message)
- ✅ Fixed typo in ServicesView: "services(s)" → "service(s)"

## Why?
The button's placement in variables/services sections didn't align with its function. Manifest editing relates to package management, not variable or service configuration. The new placement makes it clearer that editing the manifest is primarily for managing packages.

## Testing
To test:
1. Launch Extension Development Host (F5)
2. Open a Flox environment workspace
3. Remove all packages to see InstallView empty state
4. Verify both "Install a package" and "Edit manifest.toml" buttons appear
5. Verify VarsView and ServicesView show welcome messages without the Edit button

## Implementation
Simple JSON-only changes in `package.json` - no TypeScript code changes needed.

Fixes #186