### PR TITLE
ci: Remove --pre-release flag for stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,13 +135,11 @@ jobs:
           command: |
             vsce publish \
               --pat "${{ secrets.MANAGED_FLOX_VSCODE_AZURE_DEVOPS_TOKEN_MANAGE_MARKETPLACE }}" \
-              --allow-star-activation \
-              --pre-release
+              --allow-star-activation
 
       - name: "Publish to Open-VSX.org"
         uses: "flox/activate-action@main"
         with:
           command: |
             ovsx publish \
-              --pat "${{ secrets.MANAGED_FLOX_VSCODE_OPEN_VSX_TOKEN_MARKETPLACE }}" \
-              --pre-release
+              --pat "${{ secrets.MANAGED_FLOX_VSCODE_OPEN_VSX_TOKEN_MARKETPLACE }}"


### PR DESCRIPTION
## Summary

Remove the `--pre-release` flag from both VS Code Marketplace and Open-VSX publishing steps so that releases are published as stable versions.

## Changes

- Remove `--pre-release` from `vsce publish` command
- Remove `--pre-release` from `ovsx publish` command