### PR TITLE
feat: Integration registry + extension host restart

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -71,6 +71,9 @@ export default class Env implements vscode.Disposable {
   // Status bar update function (set from extension.ts)
   updateStatusBar?: () => void;
 
+  // Callback invoked at the end of reload() — used for integration checks
+  onReload?: () => void;
+
   constructor(
     ctx: vscode.ExtensionContext,
     workspaceUri?: vscode.Uri,
@@ -657,6 +660,11 @@ export default class Env implements vscode.Disposable {
     // Update status bar
     if (this.updateStatusBar) {
       this.updateStatusBar();
+    }
+
+    // Invoke onReload callback (e.g. integration checks)
+    if (this.onReload) {
+      this.onReload();
     }
 
     this.log(`[RELOAD] Reload complete!`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,49 @@ async function showAutoActivatePrompt(
   }
 }
 
+/**
+ * Offer to restart the extension host after integration settings changed.
+ * Skips in test mode. Skips if no changes were made.
+ */
+export async function offerIntegrationRestart(
+  context: vscode.ExtensionContext,
+  output: vscode.OutputChannel,
+  changedCount: number,
+): Promise<void> {
+  if (context.extensionMode === vscode.ExtensionMode.Test) {
+    return;
+  }
+  if (changedCount === 0) {
+    return;
+  }
+
+  output.appendLine(
+    `[INTEGRATIONS] ${changedCount} setting(s) changed, offering restart`
+  );
+
+  const action = await vscode.window.showInformationMessage(
+    `Updated ${changedCount} VS Code setting(s) for Flox-provided tools. ` +
+    'Restart the extension host so target extensions pick up the new paths?',
+    'Restart Now',
+    'Later',
+  );
+
+  if (action === 'Restart Now') {
+    output.appendLine('[INTEGRATIONS] User chose Restart Now');
+    if (vscode.env.remoteName === undefined) {
+      await vscode.commands.executeCommand(
+        'workbench.action.restartExtensionHost'
+      );
+    } else {
+      await vscode.commands.executeCommand(
+        'workbench.action.reloadWindow'
+      );
+    }
+  } else {
+    output.appendLine('[INTEGRATIONS] User chose Later or dismissed');
+  }
+}
+
 export async function activate(context: vscode.ExtensionContext) {
 
   const output = vscode.window.createOutputChannel('Flox');


### PR DESCRIPTION
## Summary

- Add exported `offerIntegrationRestart()` helper to `extension.ts` that prompts to restart the extension host when VS Code settings change for Flox-provided tools. Skips in test mode and when change count is zero. Uses the same local/remote restart pattern as `flox.activate`.
- Add `onReload` callback to `Env` class, invoked at the end of `reload()` so callers can react to manifest changes (e.g. re-scan integrations).

## Test plan

- [ ] `npm run compile` succeeds
- [ ] `npm run test:unit` passes (158 tests)
- [ ] Verify `offerIntegrationRestart` is exported and callable from other modules