### PR TITLE
chore: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,8 @@ jobs:
       issues: write
     steps:
     - name: Add team label automatically to new issues and PRs
-      uses: actions-ecosystem/action-add-labels@v1
+      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+
       with:
         github_token: "${{ secrets.GITHUB_TOKEN }}"
         labels: "team-developer-support" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,18 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
         with:
           fetch-depth: 0
 
       - name: "Install Flox"
-        uses: "flox/install-flox-action@main"
+        uses: flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a # main
+
 
       - name: "Restore npm cache"
-        uses: "actions/cache@v5"
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+
         with:
           path: |
             ~/.npm
@@ -53,17 +56,20 @@ jobs:
             ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}-
 
       - name: "Install"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: "npm ci"
 
       - name: "Lint"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: "npm run lint"
 
       - name: "Build"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: "npm run compile"
 
@@ -79,12 +85,14 @@ jobs:
 
       - name: "Package"
         id: "package"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: "npm run package -- --out flox-latest.vsix"
 
       - name: "Upload vscode extention as artifact"
-        uses: "actions/upload-artifact@v7"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+
         with:
           name: "flox-latest-${{ matrix.os }}.vsix"
           path: "flox-latest.vsix"
@@ -103,15 +111,18 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
         with:
           fetch-depth: 0
 
       - name: "Install Flox"
-        uses: "flox/install-flox-action@main"
+        uses: flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a # main
+
 
       - name: "Restore npm cache"
-        uses: "actions/cache@v5"
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+
         with:
           path: |
             ~/.npm
@@ -120,17 +131,20 @@ jobs:
             ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}-
 
       - name: "Install"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: "npm ci"
 
       - name: "Download Build Artifact"
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+
         with:
           name: "flox-latest-ubuntu-latest.vsix"
 
       - name: "Publish to Visual Studio Marketplace"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: |
             vsce publish \
@@ -138,7 +152,8 @@ jobs:
               --allow-star-activation
 
       - name: "Publish to Open-VSX.org"
-        uses: "flox/activate-action@main"
+        uses: flox/activate-action@d2c0d305d166520ed1cc2485bf10cd83cd859674 # main
+
         with:
           command: |
             ovsx publish \

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,16 +17,19 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
 
       - name: "Install flox"
-        uses: "flox/install-flox-action@main"
+        uses: flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a # main
+
 
       - name: "Run upgrade"
         run: "flox -vvv upgrade"
 
       - name: "Create Pull Request"
-        uses: "peter-evans/create-pull-request@v8"
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+
         with:
           token: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
           add-paths: ".flox"


### PR DESCRIPTION
## Summary

Pin all external action references to immutable commit SHAs to mitigate supply chain attacks.

## Test plan

- [ ] CI passes

Tracking: https://github.com/flox/product/issues/1302