### PR TITLE
test: stub network calls in checkForFloxUpdate tests

### DIFF
--- a/src/test/unit/env.test.ts
+++ b/src/test/unit/env.test.ts
@@ -734,7 +734,9 @@ MY_VAR = "test_value"
       const workspaceUri = vscode.Uri.file(tempDir);
       const env = new Env(mockContext, workspaceUri);
 
-      // Should not throw even if network is unavailable
+      env.getFloxVersion = async () => '1.3.1';
+      env.getLatestFloxVersion = async () => '1.3.1';
+
       await env.checkForFloxUpdate();
       env.dispose();
     });
@@ -758,6 +760,9 @@ MY_VAR = "test_value"
       const mockOutput = new MockOutputChannel('Flox');
       const env = new Env(mockContext, workspaceUri, mockOutput);
 
+      env.getFloxVersion = async () => '1.3.1';
+      env.getLatestFloxVersion = async () => '1.3.1';
+
       // Set last check to 1 hour ago (within 24hr window)
       const oneHourAgo = Date.now() - (60 * 60 * 1000);
       await mockContext.globalState.update('flox.lastUpdateCheck', oneHourAgo);
@@ -778,6 +783,9 @@ MY_VAR = "test_value"
       const workspaceUri = vscode.Uri.file(tempDir);
       const mockOutput = new MockOutputChannel('Flox');
       const env = new Env(mockContext, workspaceUri, mockOutput);
+
+      env.getFloxVersion = async () => '1.3.1';
+      env.getLatestFloxVersion = async () => '1.3.1';
 
       // Set last check to now
       await mockContext.globalState.update('flox.lastUpdateCheck', Date.now());


### PR DESCRIPTION
## Summary

Three unit tests in `env.test.ts > checkForFloxUpdate` were accidentally making real HTTPS calls to `api.github.com` via `getLatestFloxVersion()`. Starting ~April 13, those requests began hanging long enough on GitHub Actions runners to hit the 10s HTTPS timeout, which coincides exactly with mocha's 10s test timeout — so the tests fail.

The passing test in the same suite (`should skip check if checked within last 24 hours`) hits the cooldown early-return and never touches the network, which is why it alone survived.

## Fix

Stub `getFloxVersion` and `getLatestFloxVersion` on the `Env` instance in the three affected tests. They exercise cooldown/force logic and log-line assertions — they don't care what version the API returns, just that the code path runs.

## Test plan

- [x] CI passes on ubuntu-latest and macos-latest
- [x] The three previously-failing tests now pass
- [x] Existing passing tests still pass