### PR TITLE
chore: add Renovate, disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,6 @@
 version: 2
-updates:
-
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 1
-  commit-message:
-      prefix: "chore"
-      include: "scope"
-  groups:
-    all:
-      patterns:
-        - "*"
-
-- package-ecosystem: npm
-  directory: '/'
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 1
-  commit-message:
-      prefix: "chore"
-      include: "scope"
-  groups:
-    all:
-      patterns:
-        - "*"
+# Dependabot version updates are disabled — Renovate handles all
+# remediation PRs (see .github/workflows/renovate.yml + renovate.json).
+# Dependabot ALERTS remain enabled in repo settings and continue to
+# feed the GitHub Security tab; only PR creation is migrated.
+updates: []

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,74 @@
+name: "Renovate"
+
+# Self-hosted Renovate via GitHub Actions.
+# All variable inputs are either workflow_dispatch choice fields (validated
+# against a fixed option list) or the static github.repository slug, passed
+# to the action via env: per GitHub's workflow-injection guidance.
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+        type: choice
+        options:
+          - "debug"
+          - "info"
+          - "warn"
+      dryRun:
+        description: "Override renovate.json dryRun (blank = use file value)"
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - "lookup"
+          - "extract"
+          - "full"
+
+concurrency:
+  group: "renovate"
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: "Renovate"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+
+    steps:
+      - name: "Mint installation token from Renovate GitHub App"
+        id: "app-token"
+        uses: "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1" # v3.2.0
+        with:
+          app-id: "${{ secrets.RENOVATE_APP_ID }}"
+          private-key: "${{ secrets.RENOVATE_APP_PRIVATE_KEY }}"
+
+      - name: "Checkout"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: "Self-hosted Renovate"
+        uses: "renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961" # v46.1.14
+        env:
+          LOG_LEVEL: "${{ inputs.logLevel || 'info' }}"
+          RENOVATE_PLATFORM: "github"
+          RENOVATE_AUTODISCOVER: "false"
+          RENOVATE_REPOSITORIES: "${{ github.repository }}"
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_REQUIRE_CONFIG: "required"
+          # Safety net: any run NOT on main is forced into full dry-run.
+          # Prevents stray branch runs from opening real PRs/issues.
+          RENOVATE_DRY_RUN: "${{ github.ref != 'refs/heads/main' && 'full' || inputs.dryRun }}"
+          RENOVATE_PERSIST_REPO_DATA: "true"
+        with:
+          configurationFile: "renovate.json"
+          token: "${{ steps.app-token.outputs.token }}"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "timezone": "UTC",
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  "branchConcurrentLimit": 0,
+  "automerge": false,
+  "rebaseWhen": "behind-base-branch",
+  "configMigration": true,
+  "minimumReleaseAge": "7 days",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "* 0-6 * * 1"
+    ],
+    "commitMessageAction": "Refresh"
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security"
+    ],
+    "minimumReleaseAge": "1 day",
+    "schedule": [
+      "at any time"
+    ]
+  },
+  "osvVulnerabilityAlerts": true,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate dependency dashboard",
+  "packageRules": [
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "npm dev-deps (minor + patch)"
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "npm runtime-deps (minor + patch)"
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "labels": [
+        "major-upgrade"
+      ]
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "groupName": "github-actions (minor + patch + digest)",
+      "pinDigests": true
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "labels": [
+        "major-upgrade"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "@types/node",
+        "node"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adopts self-hosted Renovate via GitHub Actions for dependency-update PRs on this repo as the pilot for an org-wide migration. Dependabot **alerts** in the Security tab remain enabled (controlled in repo settings, not this file); only PR creation is migrated.

Why Renovate:

- Handles transitive lockfile refreshes (`lockFileMaintenance`) — the gap behind the three currently-open `fast-uri` / `ip-address` alerts that Dependabot can't auto-close.
- Consumes the same GitHub Advisory feed for vulnerability remediation via `vulnerabilityAlerts`.
- Native cooldown windows (`minimumReleaseAge`) for supply-chain protection.
- Smarter grouping — failures in one group don't poison others, and the dependency dashboard issue gives a single view of pending work.

Pilot config choices ([`renovate.json`](./renovate.json)):

- 7-day cooldown on routine updates, 1-day on security.
- Separate groups for npm dev-deps, npm runtime-deps, and github-actions (minor + patch + digest).
- Major bumps open individual PRs labelled `major-upgrade`.
- Weekly `lockFileMaintenance` on Monday 0-6 UTC.
- `@types/node` and `node` major bumps disabled (pegged to the extension's `engines.vscode` baseline).
- Dry-run safety net: any workflow run on a branch other than `main` is forced into `dryRun=full`, preventing stray branch runs from opening real PRs.

Auth uses a GitHub App (`flox-renovate`) installed on this repo, via repo-scoped secrets `RENOVATE_APP_ID` and `RENOVATE_APP_PRIVATE_KEY`. All third-party actions in [`renovate.yml`](./.github/workflows/renovate.yml) are SHA-pinned per the repo's `actions.permissions.sha_pinning_required` policy.

## Test plan

Verified on `chore/renovate-pilot` before squashing:

- [x] App token mint succeeds (`actions/create-github-app-token`)
- [x] All three actions download and execute (SHA pinning works)
- [x] Renovate binary runs to completion with no errors
- [x] Dry-run safety net engages on the feature branch
- [x] `renovate-config-validator --strict` passes on `renovate.json`

After merge:

- [ ] First scheduled (or manually-triggered) run on `main` opens PRs for pending updates
- [ ] Dependency dashboard issue appears
- [ ] Within one weekly cycle, `lockFileMaintenance` closes the open `fast-uri` and `ip-address` alerts
- [ ] CI passes on Renovate PRs

## Rollback

Single revert of this PR + uninstall the `flox-renovate` GitHub App from the repo. The Dependabot alert feed and any compliance integrations are untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)