### PR TITLE
chore: tune Renovate cadence and remove stale Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-# Dependabot version updates are disabled — Renovate handles all
-# remediation PRs (see .github/workflows/renovate.yml + renovate.json).
-# Dependabot ALERTS remain enabled in repo settings and continue to
-# feed the GitHub Security tab; only PR creation is migrated.
-updates: []

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,7 +7,15 @@ name: "Renovate"
 
 on:
   schedule:
-    - cron: "0 */4 * * *"
+    # Daily at 12:00 UTC. The 7-day minimumReleaseAge cooldown in
+    # renovate.json dominates the latency for routine updates, so more
+    # frequent runs add cost (Actions minutes) and noise (transient
+    # GitHub-API failures) without faster outcomes. Vulnerability
+    # alerts use a 1-day cooldown, so CVE-patch PRs open within ~24h
+    # of the cooldown clearing — fine for a dev tool. Production-class
+    # repos should override this to a more frequent cadence in their
+    # per-repo renovate.yml.
+    - cron: "0 12 * * *"
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
## Summary

Two related cleanup changes to the Renovate setup, neither of which affects Dependabot **alerts** in the Security tab.

### 1. Drop Renovate cron from every-4h to daily

Changes `.github/workflows/renovate.yml` schedule from `0 */4 * * *` to `0 12 * * *`.

The 7-day `minimumReleaseAge` cooldown in [`renovate.json`](./renovate.json) dominates latency for routine updates, so a 4-hour cadence was producing ~23 no-op runs per useful one. Trade-offs reviewed:

- **Vulnerability response.** `vulnerabilityAlerts.minimumReleaseAge` is `1 day`, scheduled `at any time`. With a daily cron, CVE-patch PRs open within ~24h of cooldown clearing. Fine for a dev tool; production-class repos should override to a faster cadence.
- **Cost.** Public repos: $0 impact. At fleet scale on private repos: 4h cadence ≈ 6× the runner-minutes vs daily. Material at 100+ repos.
- **Transient-failure surface.** One `401 bad-credentials` blip was observed on 2026-05-23 (resolved on the next scheduled run). Fewer runs = fewer chances for transients.
- **Manual triggering.** `workflow_dispatch` remains available for force-runs.

Confirmed against the [official `renovatebot/github-action` README example](https://github.com/renovatebot/github-action) (every 15min, tuned for demos), [Renovate's scheduling docs](https://docs.renovatebot.com/key-concepts/scheduling/) (no prescribed cadence), and community examples (mostly hourly or daily).

### 2. Delete `.github/dependabot.yml`

The previous "disable but keep the file" approach used `updates: []` to leave a marker in place. That turned out to be **invalid per Dependabot's schema** — the `updates` list requires ≥1 item. Dependabot rejected the file and fell back to its last-validated config, opening a phantom PR ([#269](https://github.com/flox/flox-vscode/pull/269)) three days later with the old `groups: all` rule that no longer existed on `main`.

Deleting the file removes the staleness foot-gun. Dependabot **alerts** in the Security tab are controlled by repo settings (`security_and_analysis.dependabot_security_updates`), not this file, and continue to flow to Sprinto and the Security tab unchanged.

The valid-but-disabled alternative (explicit `open-pull-requests-limit: 0` blocks per ecosystem) was considered but rejected — the file's purpose is gone now that Renovate fully owns dependency-update PR creation. Leaving a file just to document "we used to use Dependabot here" isn't worth the per-repo maintenance and re-staleness risk.

## Test plan

- [x] Schedule change is syntactically valid (cron `0 12 * * *`)
- [x] Dependabot config-file deletion preserves alerts (controlled by repo settings, separate code path)
- [ ] CI passes
- [ ] Next scheduled Renovate run fires at 12:00 UTC tomorrow
- [ ] Manual `workflow_dispatch` still works after merge
- [ ] No new phantom Dependabot PRs appear in the week after merge (the `updates: []`-induced fallback should stop firing once the file is gone)

## Follow-up

Plan finding to be added: future repo onboardings in the fleet should delete `.github/dependabot.yml` outright rather than emptying it. The current `dependabot.yml`-stays-as-marker pattern in the plan is incorrect and will produce phantom PRs on every repo that uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)