### PR TITLE
fix(services): exclude auto-start setting from service name list

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -435,14 +435,24 @@ export default class Env implements vscode.Disposable {
     const lockServices = this.manifest?.manifest?.services || {};
     const tomlServices = this.tomlManifest?.services || {};
 
+    const isServiceEntry = (v: unknown) =>
+      typeof v === 'object' && v !== null && !Array.isArray(v);
+
     const serviceNames = new Set<string>();
-    for (const name of Object.keys(lockServices)) {
-      serviceNames.add(name);
+    for (const [name, value] of Object.entries(lockServices)) {
+      if (isServiceEntry(value)) { serviceNames.add(name); }
     }
-    for (const name of Object.keys(tomlServices)) {
-      serviceNames.add(name);
+    for (const [name, value] of Object.entries(tomlServices)) {
+      if (isServiceEntry(value)) { serviceNames.add(name); }
     }
     return Array.from(serviceNames);
+  }
+
+  getAutoStartEnabled(): boolean {
+    return !!(
+      this.tomlManifest?.services?.['auto-start'] ??
+      this.manifest?.manifest?.services?.['auto-start']
+    );
   }
 
   /**

--- a/src/test/unit/env.test.ts
+++ b/src/test/unit/env.test.ts
@@ -1719,6 +1719,62 @@ myservice.command = "sleep 1000"
       assert.strictEqual(state, 'active', 'Service with same properties (different order) should be ACTIVE');
       env.dispose();
     });
+
+    test('should not include auto-start key as a service name', async () => {
+      const floxDir = path.join(tempDir, '.flox', 'env');
+      fs.mkdirSync(floxDir, { recursive: true });
+
+      fs.writeFileSync(path.join(floxDir, 'manifest.toml'), `
+[services]
+auto-start = true
+
+[services.myservice]
+command = "sleep 1000"
+`);
+
+      const env = new Env(mockContext, vscode.Uri.file(tempDir));
+      await env.reload();
+
+      const names = env.getMergedServiceNames();
+      assert.ok(!names.includes('auto-start'), 'auto-start should not appear as a service name');
+      assert.ok(names.includes('myservice'), 'myservice should appear as a service name');
+      env.dispose();
+    });
+
+    test('should report getAutoStartEnabled() true when auto-start = true in toml', async () => {
+      const floxDir = path.join(tempDir, '.flox', 'env');
+      fs.mkdirSync(floxDir, { recursive: true });
+
+      fs.writeFileSync(path.join(floxDir, 'manifest.toml'), `
+[services]
+auto-start = true
+
+[services.myservice]
+command = "sleep 1000"
+`);
+
+      const env = new Env(mockContext, vscode.Uri.file(tempDir));
+      await env.reload();
+
+      assert.strictEqual(env.getAutoStartEnabled(), true, 'getAutoStartEnabled should return true');
+      env.dispose();
+    });
+
+    test('should report getAutoStartEnabled() false when auto-start not set', async () => {
+      const floxDir = path.join(tempDir, '.flox', 'env');
+      fs.mkdirSync(floxDir, { recursive: true });
+
+      fs.writeFileSync(path.join(floxDir, 'manifest.toml'), `
+[services.myservice]
+command = "sleep 1000"
+`);
+
+      const env = new Env(mockContext, vscode.Uri.file(tempDir));
+      await env.reload();
+
+      assert.strictEqual(env.getAutoStartEnabled(), false, 'getAutoStartEnabled should return false when not set');
+      env.dispose();
+    });
   });
 
   /**

--- a/src/view.ts
+++ b/src/view.ts
@@ -206,12 +206,12 @@ export class VarsView implements View, vscode.TreeDataProvider<PackageItem> {
   }
 }
 
-export class ServicesView implements View, vscode.TreeDataProvider<PackageItem> {
+export class ServicesView implements View, vscode.TreeDataProvider<vscode.TreeItem> {
 
   env?: Env;
 
-  private _onDidChangeTreeData: vscode.EventEmitter<PackageItem | undefined | null | void> = new vscode.EventEmitter<PackageItem | undefined | null | void>();
-  readonly onDidChangeTreeData: vscode.Event<PackageItem | undefined | null | void> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
   async refresh() {
     this._onDidChangeTreeData.fire();
@@ -221,19 +221,21 @@ export class ServicesView implements View, vscode.TreeDataProvider<PackageItem> 
     return vscode.window.registerTreeDataProvider(viewName, this);
   }
 
-  getTreeItem(service: ServiceItem): vscode.TreeItem {
-    return service;
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
   }
 
-  async getChildren(service?: ServiceItem): Promise<ServiceItem[]> {
+  async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
     const envExists = this.env?.context.workspaceState.get('flox.envExists', false);
     if (!envExists) {
       return [];
     }
 
-    if (!service) {
+    if (!element) {
       const serviceNames = this.env?.getMergedServiceNames() || [];
-      if (serviceNames.length === 0) {
+      const autoStart = this.env?.getAutoStartEnabled?.() ?? false;
+
+      if (serviceNames.length === 0 && !autoStart) {
         return [];
       }
 
@@ -248,10 +250,20 @@ export class ServicesView implements View, vscode.TreeDataProvider<PackageItem> 
       });
 
       // Sort: active items first, then pending
-      return result.sort((a, b) => {
+      const sorted = result.sort((a, b) => {
         if (a.state === b.state) { return 0; }
         return a.state === ItemState.ACTIVE ? -1 : 1;
       });
+
+      if (autoStart) {
+        const indicator = new vscode.TreeItem('Auto-start on activate');
+        indicator.iconPath = new vscode.ThemeIcon('play-circle');
+        indicator.tooltip = 'Services will start automatically on flox activate';
+        indicator.contextValue = 'auto-start-setting';
+        return [indicator, ...sorted];
+      }
+
+      return sorted;
     }
 
     return [];


### PR DESCRIPTION

<img width="311" height="120" alt="Screenshot 2026-07-17 at 8 41 43 PM" src="https://github.com/user-attachments/assets/04a4c6f1-90d3-4081-9c88-86b3a948adc8" />


## Summary

- Only renders label when `auto-start = true`
- `getMergedServiceNames()` now filters to object-valued keys only, so top-level scalar settings like `auto-start = true` under `[services]` are no longer treated as service names
- Adds `getAutoStartEnabled()` helper to read the setting from toml or lock
- `ServicesView` prepends an informational "Auto-start on activate" row (play-circle icon, display-only) when the setting is enabled
- Corrects a pre-existing type error: `ServicesView` was declared as `TreeDataProvider<PackageItem>` instead of `TreeDataProvider<vscode.TreeItem>`
- Three new unit tests covering the bug fix and `getAutoStartEnabled()` for true/false/absent cases

Fixes [DEV-97](https://linear.app/floxdotdev/issue/DEV-97)

🤖 Generated with [Claude Code](https://claude.com/claude-code)