### PR TITLE
chore(renovate): hold typescript at current major

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,5 +64,17 @@
       matchUpdateTypes: ["major"],
       enabled: false,
     },
+
+    // TypeScript 7.0 is the new native (Go) compiler. @typescript-eslint has
+    // no release that supports it yet — its stable peer range still caps at
+    // `typescript < 6.1.0`, so bumping to 7.x keeps tsc working but crashes
+    // eslint (typescript-estree reads TS internals the native build dropped).
+    // Hold the major; revisit once @typescript-eslint ships TS7 support.
+    {
+      description: "CUSTOM(flox-vscode): hold typescript at current major (TS7 unsupported by @typescript-eslint)",
+      matchPackageNames: ["typescript"],
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
TypeScript 7.0 is the new native (Go) compiler. `@typescript-eslint` has no release supporting it yet — its stable and canary peer ranges still cap at `typescript <6.1.0`.

Verified locally on #286's branch: `tsc` compiles fine under TS7, but `eslint` crashes:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree/.../create-program/shared.js
```

typescript-estree reads TS internals the native build dropped. Upstream support is tracked but unreleased: typescript-eslint/typescript-eslint#10940 (open).

This adds a Renovate rule to hold the `typescript` major (same pattern already used for `@types/node`). Closes the door on #286 until eslint tooling supports TS7.

Follow-up: closing #286.