### PR TITLE
test(manifest): verify [plugins] section parses without error (DEV-193)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.32.1",
         "@vscode/test-cli": "^0.0.15",
-        "@vscode/test-electron": "^3.0.0",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.8.0",
         "eslint": "^10.2.0",
         "fantasticon": "^4.1.0",
@@ -1782,9 +1782,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
-      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.32.1",
     "@vscode/test-cli": "^0.0.15",
-    "@vscode/test-electron": "^3.0.0",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.8.0",
     "eslint": "^10.2.0",
     "fantasticon": "^4.1.0",

--- a/src/test/unit/env.test.ts
+++ b/src/test/unit/env.test.ts
@@ -266,6 +266,31 @@ MY_VAR = "test_value"
       assert.strictEqual(result, undefined, 'Should return undefined for invalid JSON');
       env.dispose();
     });
+
+    test('should parse manifest with [plugins] section without error', async () => {
+      const testFilePath = path.join(tempDir, 'manifest-plugins.toml');
+      fs.writeFileSync(testFilePath, `
+[install]
+nodejs = {}
+
+[plugins.my-plugin]
+some_config = "some-value"
+
+[plugins.other-plugin]
+key = "value"
+nested = { a = "1", b = "2" }
+`);
+
+      const workspaceUri = vscode.Uri.file(tempDir);
+      const env = new Env(mockContext, workspaceUri);
+
+      const result = await env.loadFile(vscode.Uri.file(testFilePath));
+      assert.ok(result, 'Should return parsed object — plugins section does not crash parser');
+      assert.ok(result.plugins, 'Should preserve plugins key in parsed object');
+      assert.ok(result.plugins['my-plugin'], 'Should parse plugin subtable');
+      assert.strictEqual(result.plugins['my-plugin'].some_config, 'some-value');
+      env.dispose();
+    });
   });
 
   /**


### PR DESCRIPTION
## Summary

- Adds a unit test proving the extension handles `[plugins]` in `manifest.toml` without crashing (DEV-193)
- `smol-toml` parses arbitrary TOML sections to plain JS objects; the test documents this guarantee

## Analysis

The VS Code extension is safe with `[plugins]` for three reasons:

1. **smol-toml is permissive** — `loadFile()` produces a plain `any`-typed JS object. A `[plugins.my-plugin]` section becomes `{ plugins: { "my-plugin": { ... } } }` without any parser error.
2. **Views only access named sections** — `InstallView`, `VarsView`, `ServicesView` access `install`, `vars`, `services` by name; `plugins` is silently ignored.
3. **No JSON schema contributions** — `package.json` contributes only a TextMate grammar, so no schema-based squiggles fire.

The only conditional behavior: `validateManifest()` calls `flox list`. On a pre-v1.14.0 CLI, this correctly surfaces an "unknown field `plugins`" error diagnostic. On v1.14.0+, it passes cleanly.

> [!NOTE]
> Also bumps `@vscode/test-electron` from 3.0.0 → 3.1.0. VS Code 1.131.0 renamed the macOS app binary from `Electron` to `Code` and removed the backward-compat symlink that had been in place since 1.110. The old version hardcoded the `Electron` name, causing `spawn ... ENOENT` on every macOS CI run since ~July 31. 3.1.0 reads `product.json` to resolve the binary name dynamically.

## Test plan

- [ ] CI passes on both ubuntu-latest and macos-latest
- [ ] `should parse manifest with [plugins] section without error` appears in the `loadFile` suite

Closes DEV-193

---
*Via Forge (interactive) • d5ed3916*